### PR TITLE
Add new password validation messages

### DIFF
--- a/fa.json
+++ b/fa.json
@@ -133,5 +133,9 @@
     "The :attribute must be a valid role.": "فیلد :attribute باید یک نقش درست باشد.",
     "The :attribute must be at least :length characters and contain at least one special character.": "فیلد :attribute باید حداقل :length کاراکتر و شامل یک کاراکتر مخصوص باشد.",
     "The :attribute must be at least :length characters and contain at least one uppercase character and one special character.": "فیلد :attribute باید حداقل :length کاراکتر و شامل یک کاراکتر مخصوص و یک حرف بزرگ باشد.",
-    "The :attribute must be at least :length characters and contain at least one uppercase character, one number, and one special character.": "فیلد :attribute باید حداقل :length کاراکتر، یک کاراکتر مخصوص، یک حرف بزرگ و یک عدد باشد."
+    "The :attribute must be at least :length characters and contain at least one uppercase character, one number, and one special character.": "فیلد :attribute باید حداقل :length کاراکتر، یک کاراکتر مخصوص، یک حرف بزرگ و یک عدد باشد.",
+    "The :attribute must contain at least one uppercase and one lowercase letter.": "فیلد :attribute باید حداقل یک حرف بزرگ و یک حرف کوچک داشته باشد.",
+    "The :attribute must contain at least one symbol.": "فیلد :attribute باید حداقل یک نماد داشته باشد.",
+    "The :attribute must contain at least one number.": "فیلد :attribute باید حداقل یک عدد داشته باشد.",
+    "The given :attribute has appeared in a data leak. Please choose a different :attribute.": ":attribute داده شده در یک نشت داده ظاهر شده است. لطفاً یک :attribute دیگر انتخاب کنید."
 }


### PR DESCRIPTION
On this PR I have added some new password validation messages base on Laravel 10,

### Issue:
When I wanted to use 
`'password' => [ 'required',Password::min(8)->letters()->mixedCase()->numbers()->symbols()->uncompromised(),]`
I couldn't find any Farsi message for them.

### Solution:
I have added these translations

> "The :attribute must contain at least one uppercase and one lowercase letter.": "فیلد :attribute باید حداقل یک حرف بزرگ و یک حرف کوچک داشته باشد.",
    "The :attribute must contain at least one symbol.": "فیلد :attribute باید حداقل یک نماد داشته باشد.",
    "The :attribute must contain at least one number.": "فیلد :attribute باید حداقل یک عدد داشته باشد.",
    "The given :attribute has appeared in a data leak. Please choose a different :attribute.": ":attribute داده شده در یک نشت داده ظاهر شده است. لطفاً یک :attribute دیگر انتخاب کنید."

### Some screenshoots
**Before**
![image](https://github.com/mojtabaRKS/laravel-persian-validation/assets/18898699/69132d29-e274-4357-bf8b-f664e6021588)
![image](https://github.com/mojtabaRKS/laravel-persian-validation/assets/18898699/766b5d8e-2018-4a3a-925d-80ebec624a85)


**After**
![image](https://github.com/mojtabaRKS/laravel-persian-validation/assets/18898699/a1da946a-7485-4f74-b910-3f273ff30b0e)

![image](https://github.com/mojtabaRKS/laravel-persian-validation/assets/18898699/637413e0-d4dd-4329-9319-6c485dd58f24)



    